### PR TITLE
Add confusion matrix to metrics

### DIFF
--- a/solution/utils/metrics.py
+++ b/solution/utils/metrics.py
@@ -1,6 +1,10 @@
 import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+import wandb
 from functools import partial
-from sklearn.metrics import precision_recall_curve, f1_score, auc
+from sklearn.metrics import precision_recall_curve, f1_score, auc, confusion_matrix
 from .file_utils import RELATION_CLASS
 
 
@@ -23,8 +27,18 @@ def compute_auprc(probs, labels):
         scores[c] = auc(recall, precision)
     auprc = np.average(scores)
     return auprc
-    
-    
+
+
+def get_confusion_matrix(logits, labels):
+    preds = np.argmax(logits, axis=1).ravel()
+    cm = confusion_matrix(labels, preds)
+    norm_cm = cm / np.sum(cm, axis=1)[:,None]
+    cm = pd.DataFrame(norm_cm, index=RELATION_CLASS, columns=RELATION_CLASS)
+    fig = plt.figure(figsize=(12,9))
+    sns.heatmap(cm, annot=True)
+    return fig
+
+
 def compute_klue_re_leaderboard(eval_pred):
     # Parsing predictions and labels
     preds, labels = eval_pred
@@ -36,6 +50,12 @@ def compute_klue_re_leaderboard(eval_pred):
     micro_f1 = compute_micro_f1(preds, labels, label_indices)
     # Compute AURPC
     auprc = compute_auprc(preds, labels)
+    # Compute confusion matrix
+    cm_fig = get_confusion_matrix(preds, labels)
+    try:
+        wandb.log({'confusion matrix': wandb.Image(cm_fig)})
+    except:
+        print("Warning (원래는 Error): You must call wandb.init() before wandb.log()")
     return {
         "micro_f1": micro_f1,
         "auprc": auprc,


### PR DESCRIPTION
메인 베이스라인 metrics.py에 confusion matrix 로그 찍는 코드를 추가하였습니다.

다만, 이 코드가 run_hps.py 를 실행할 때도 동작하는데, 아직 hps 코드에 wandb 연결이 추가되지 않아서 오류가 발생할 수 있습니다.
따라서 이 부분은 try-except 으로 예외처리 해두었습니다. (나중에 wandb 연결되면 지워도 될 것 같아요)

확인해주시고 merge 부탁드려요! 다들 confusion matrix 그리면서 실험해봅시다✨